### PR TITLE
use latest version of google-play-services

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -43,8 +43,8 @@
         </config-file>
 
         <framework src="src/android/plugin.gradle" custom="true" type="gradleReference" />
-        <framework src="com.google.firebase:firebase-auth:9.4+" />
-        <framework src="com.google.android.gms:play-services-auth:9.4+" />
+        <framework src="com.google.firebase:firebase-auth:+" />
+        <framework src="com.google.android.gms:play-services-auth:+" />
 
         <source-file src="src/android/com/blakgeek/cordova/plugin/FirebaseAuthPlugin.java"
             target-dir="src/com/blakgeek/cordova/plugin/" />


### PR DESCRIPTION
causes issues together with cordova-plugin-fcm otherwise

```
Error: /home/tom/workspace/building-blocks-web/cordova-firebase-push/platforms/android/gradlew: Command failed with exit code 1 Error output:
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':processDebugGoogleServices'.
> Please fix the version conflict either by updating the version of the google-services plugin (information about the latest version is available at https://bintray.com/android/android-tools/com.google.gms.google-services/) or updating the version of com.google.android.gms to 9.0.0.
```